### PR TITLE
increase java heap for golr loader, neo4j pagecache, and jetty idle timeout

### DIFF
--- a/files/functions.inc
+++ b/files/functions.inc
@@ -14,7 +14,7 @@ function getGraphConfiguration()
 {
   location=$1
   printf "location: $location\n"
-  printf "neo4jConfig:\n    dump_configuration : true\n    dbms.pagecache.memory : 50G\n"
+  printf "neo4jConfig:\n    dump_configuration : true\n    dbms.pagecache.memory : 100G\n"
   printf "curies:\n"
   if [[ $(isUrl $2) == 0 ]]
   then

--- a/files/run.sh
+++ b/files/run.sh
@@ -7,12 +7,14 @@ set -e
 /data/solr-6.2.1/bin/solr stop
 rm /data/solr-6.2.1/server/solr/golr/conf/managed-schema
 cd /data/golr-schema && mvn exec:java -Dexec.mainClass="org.bbop.cli.Main" -Dexec.args="-c /data/monarch-app/conf/golr-views/oban-config.yaml -o /data/solr-6.2.1/server/solr/golr/conf/schema.xml"
+# Set jetty idle timeout to 200 seconds
+sed -i 's/<Set name="idleTimeout"><Property name="solr.jetty.http.idleTimeout" default="50000"\/><\/Set>/<Set name="idleTimeout"><Property name="solr.jetty.http.idleTimeout" default="200000"\/><\/Set>/' /data/solr-6.2.1/server/etc/jetty-http.xml
 wget -O /data/scigraph.tgz http://scigraph-data-dev.monarchinitiative.org/static_files/scigraph.tgz
 cd /data/ && tar xzfv scigraph.tgz
 mv /data/solrconfig.xml  /data/solr-6.2.1/server/solr/golr/conf/
 mkdir -p /solr/json
-/data/solr-6.2.1/bin/solr start -m 4g
-cd /data/golr-loader && java -Xmx90G -Dlogback.configurationFile=file:/data/logback.xml -jar target/golr-loader-0.0.1-SNAPSHOT.jar -g /data/graph.yaml -q /data/monarch-cypher-queries/src/main/cypher/golr-loader/ -s http://localhost:8983/solr/golr
+/data/solr-6.2.1/bin/solr start -m 10g
+cd /data/golr-loader && java -Xmx300G -Dlogback.configurationFile=file:/data/logback.xml -jar target/golr-loader-0.0.1-SNAPSHOT.jar -g /data/graph.yaml -q /data/monarch-cypher-queries/src/main/cypher/golr-loader/ -s http://localhost:8983/solr/golr
 #rm -rf /solr/json
 rm /data/scigraph.tgz
 rm -rf /data/graph/


### PR DESCRIPTION
Making the following adjustments:
- Increase java heap max on golr loader from 90G to 300G
- Increase neo4j pagecache from 50G to 100G
- Increase Jetty idle timeout from 50 seconds to 200
- Increase solr heap max from 4G to 10G

See https://github.com/SciGraph/golr-loader/pull/48